### PR TITLE
Changed location of jquery.min.js to prepare for CSP header

### DIFF
--- a/eduid_signup/templates/base.jinja2
+++ b/eduid_signup/templates/base.jinja2
@@ -47,8 +47,7 @@
      {% endblock %}
      </div>
    </div>
-   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-   <script>window.jQuery || document.write('<script src=\'{{"eduid_signup:static/js/libs/jquery-1.9.1.min.js"|static_url}}\'><\/script>')</script>
+   <script src="{{'eduid_signup:static/js/libs/jquery-1.9.1.min.js'|static_url}}"></script>
    <script src="{{'eduid_signup:static/js/libs/bootstrap-3.2.0.min.js'|static_url}}"></script>
 
    <div class="clearfix"></div>

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.rst')).read()
 CHANGES = open(os.path.join(here, 'CHANGES.rst')).read()
 
-version = '0.4.2-dev'
+version = '0.4.2.1-dev'
 
 requires = [
     'eduid_am>=0.5.1',


### PR DESCRIPTION
This change is needed if we want to minimize the trusted sources in our Content-Security-Policy header.